### PR TITLE
email_format_validator のロジック修正

### DIFF
--- a/docs/validators/email_format_validator.md
+++ b/docs/validators/email_format_validator.md
@@ -14,11 +14,11 @@ end
 validate email with strict format. see following regex.
 
 ```
-/\A([\w+\-]+\.)*[\w+\-]+@[a-z\d\-.]+\.[a-z]+\z/i
+/\A([\w+\-]+\.)*[\w+\-]+@([a-z\d\-]+\.)+[a-z]+\z/i
 ```
 
 ### Example
 
 ```ruby
-validates :email, email_format: true, strict: true
+validates :email, email_format: { strict: true }
 ```

--- a/lib/constants/palette_regex_pattern.rb
+++ b/lib/constants/palette_regex_pattern.rb
@@ -1,8 +1,8 @@
 module Constants
   module PaletteRegexPattern
-    EMAIL            = /\A([\w+\-.]+@(?!ezweb\.ne\.jp\z)[a-z\d\-.]+\.[a-z]+\z|([\w+\-]+\.)*[\w+\-]+@ezweb.ne.jp\z)/i
+    EMAIL            = /\A([\w+\-.]+@(?!ezweb\.ne\.jp\z)([a-z\d\-]+\.)+[a-z]+\z|([\w+\-]+\.)*[\w+\-]+@ezweb.ne.jp\z)/i
     EMAIL_STRICT_PRE = /\A([\w+\-]+\.)*[\w+\-]+\z/
-    EMAIL_STRICT     = /\A([\w+\-]+\.)*[\w+\-]+@[a-z\d\-.]+\.[a-z]+\z/i
+    EMAIL_STRICT     = /\A([\w+\-]+\.)*[\w+\-]+@([a-z\d\-]+\.)+[a-z]+\z/i
     EMAIL_DOMAIN     = /\A([A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9]\.)+[A-Za-z]+\z/
     PASSWORD         = /\A(?=[!-~]*[\d]+[!-~]*)(?=[!-~]*[a-z]+[!-~]*)[!-~]*[A-Z]+[!-~]*\z/
     POSTCODE         = /\A\d{3}\-\d{4}\z/

--- a/spec/lib/validators/email_format_validator_spec.rb
+++ b/spec/lib/validators/email_format_validator_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe EmailFormatValidator, type: :model do
 
   context 'strict: false' do
     let(:strict) { false }
-    EMAIL            = /\A([\w+\-.]+@(?!ezweb\.ne\.jp\z)[a-z\d\-.]+\.[a-z]+\z|([\w+\-]+\.)*[\w+\-]+@ezweb.ne.jp\z)/i
 
     it_behaves_like 'valid email address', 'test@example.com'
 

--- a/spec/lib/validators/email_format_validator_spec.rb
+++ b/spec/lib/validators/email_format_validator_spec.rb
@@ -1,0 +1,151 @@
+require "spec_helper"
+
+module Test
+  EmailFormatValidatable = Struct.new(:email, :strict) do
+    include ActiveModel::Validations
+
+    validates :email, email_format: true,             unless: :strict
+    validates :email, email_format: { strict: true }, if:     :strict
+  end
+end
+
+RSpec.describe EmailFormatValidator, type: :model do
+  subject { model.valid? }
+
+  let(:model) { Test::EmailFormatValidatable.new(email, strict) }
+
+  shared_examples_for 'valid email address' do |email|
+    context "email is '#{email}'" do
+      let(:email) { email }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  shared_examples_for 'invalid email address' do |email|
+    context "email is '#{email}'" do
+      let(:email) { email }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  context 'strict: false' do
+    let(:strict) { false }
+    EMAIL            = /\A([\w+\-.]+@(?!ezweb\.ne\.jp\z)[a-z\d\-.]+\.[a-z]+\z|([\w+\-]+\.)*[\w+\-]+@ezweb.ne.jp\z)/i
+
+    it_behaves_like 'valid email address', 'test@example.com'
+
+    context "host includes '.'" do
+      it_behaves_like 'valid email address', 'test.test@example.com'
+    end
+
+    context "host includes '_'" do
+      it_behaves_like 'valid email address', 'test_test@example.com'
+    end
+
+    context "host includes '-'" do
+      it_behaves_like 'valid email address', 'test-test@example.com'
+    end
+
+    context "host includes '+'" do
+      it_behaves_like 'valid email address', 'test+test@example.com'
+    end
+
+    context 'domain consists of threee parts' do
+      it_behaves_like 'valid email address', 'test@example.example.com'
+    end
+
+    context "host includes successive '.'" do
+      it_behaves_like 'valid email address', 'test..test@example.com'
+    end
+
+    context "host includes '.' just before '@'" do
+      it_behaves_like 'valid email address', 'test.@example.com'
+    end
+
+    context 'email with length = 200' do
+      it_behaves_like 'valid email address', 't' * 188 + '@example.com'
+    end
+
+    context 'domain does not have top level domain' do
+      it_behaves_like 'invalid email address', 'test@example'
+    end
+
+    context "domain includes successive '.'" do
+      it_behaves_like 'invalid email address', 'test@example..com'
+    end
+
+    context "domain includes '.' next to '@'" do
+      it_behaves_like 'invalid email address', 'test@.example.com'
+    end
+
+    context 'email with length = 201' do
+      it_behaves_like 'invalid email address', 't' * 189 + '@example.com'
+    end
+
+    context "domain is 'ezweb.ne.jp'" do
+      context "host includes successive '.'" do
+        it_behaves_like 'invalid email address', 'test..test@ezweb.ne.jp'
+      end
+
+      context "host includes '.' just before '@'" do
+        it_behaves_like 'invalid email address', 'test.@ezweb.ne.jp'
+      end
+    end
+  end
+
+  context 'strict: true' do
+    let(:strict) { true }
+
+    it_behaves_like 'valid email address', 'test@example.com'
+
+    context "host includes '.'" do
+      it_behaves_like 'valid email address', 'test.test@example.com'
+    end
+
+    context "host includes '_'" do
+      it_behaves_like 'valid email address', 'test_test@example.com'
+    end
+
+    context "host includes '-'" do
+      it_behaves_like 'valid email address', 'test-test@example.com'
+    end
+
+    context "host includes '+'" do
+      it_behaves_like 'valid email address', 'test+test@example.com'
+    end
+
+    context 'domain consists of threee parts' do
+      it_behaves_like 'valid email address', 'test@example.example.com'
+    end
+
+    context 'email with length = 200' do
+      it_behaves_like 'valid email address', 't' * 188 + '@example.com'
+    end
+
+    context "host includes successive '.'" do
+      it_behaves_like 'invalid email address', 'test..test@example.com'
+    end
+
+    context "host includes '.' just before '@'" do
+      it_behaves_like 'invalid email address', 'test.@example.com'
+    end
+
+    context 'domain does not have top level domain' do
+      it_behaves_like 'invalid email address', 'test@example'
+    end
+
+    context "domain includes successive '.'" do
+      it_behaves_like 'invalid email address', 'test@example..com'
+    end
+
+    context "domain includes '.' next to '@'" do
+      it_behaves_like 'invalid email address', 'test@.example.com'
+    end
+
+    context 'email with length = 201' do
+      it_behaves_like 'invalid email address', 't' * 189 + '@example.com'
+    end
+  end
+end


### PR DESCRIPTION
過去1ヶ月分の送信エラーを見たところ、すべてドメイン不正に依るものでした。（2020/10/08 09:49現在）
そのため、以下のドメイン不正なパターンを弾くよう、修正しました。

* '@' の直後に '.'
* '.' 連続

## 既存のバリデーション設定チェック
パレット管理で `email_format` を利用している箇所を確認しました。
そのうち、 `, if: :will_save_change_to_{attribute}?` 判定のなかったものは以下です。
（フォームは含んでいません）

```
Elec::SubscriptionForm
Elec::Ens::VacancyAccept
（ Elec::SubscriptionForm と Elec::Entry が無事ならOK）
ElecV2::SwitchingContract
Mast::SupportCenter::Entry
MobileApp::Settings::ReviewInformation
MobileApp::Settings::TradeRepresentativeContactInformation
Renewal::ConditionPerson
Renewal::EntryPerson
```

本番のデータを確認したところ、不正なドメインのメールアドレスはありませんでしたが、
念の為 `will_save_change_to_{attribute}?` をつけておきます。

```
Elec::SubscriptionForm.where("contactor_email NOT REGEXP ?", '@([-a-z0-9]+\.)+[a-zA-Z]+$').where.not(contactor_email: [nil, '']).first
Elec::Entry.where("applicant_email NOT REGEXP ?", '@([-a-z0-9]+\.)+[a-zA-Z]+$').where.not(applicant_email: [nil, '']).first
ElecV2::SwitchingContract.where("contractor_email NOT REGEXP ?", '@([-a-z0-9]+\.)+[a-zA-Z]+$').where.not(contractor_email: [nil, '']).first
MobileApp::Settings::ReviewInformation.where("email_address NOT REGEXP ?", '@([-a-z0-9]+\.)+[a-zA-Z]+$').where.not(email_address: [nil, '']).first
MobileApp::Settings::TradeRepresentativeContactInformation.where("email_address NOT REGEXP ?", '@([-a-z0-9]+\.)+[a-zA-Z]+$').where.not(email_address: [nil, '']).first

Company.all.each do |c|
  Apartment::Tenant.switch(c.db_uid) do
    puts Mast::SupportCenter::Entry.where("email NOT REGEXP ?", '@([-a-z0-9]+\.)+[a-zA-Z]+$').where.not(email: [nil, '']).first&.email
    puts Renewal::ConditionPerson.where("email NOT REGEXP ?", '@([-a-z0-9]+\.)+[a-zA-Z]+$').where.not(email: [nil, '']).first&.email
    puts Renewal::EntryPerson.where("email NOT REGEXP ?", '@([-a-z0-9]+\.)+[a-zA-Z]+$').where.not(email: [nil, '']).first&.email
  end
end.nil?
```