### PR TITLE
modify email format validator regular expression

### DIFF
--- a/lib/constants/palette_regex_pattern.rb
+++ b/lib/constants/palette_regex_pattern.rb
@@ -1,6 +1,6 @@
 module Constants
   module PaletteRegexPattern
-    EMAIL            = /\A([\w+\-.]+@(?!ezweb\.ne\.jp\z)([a-z\d\-]+\.)+[a-z]+\z|([\w+\-]+\.)*[\w+\-]+@ezweb.ne.jp\z)/i
+    EMAIL            = /\A([\w+\-.]+@(?!ezweb\.ne\.jp\z)([a-z\d\-]+\.)+[a-z]+\z|([\w+\-]+\.)*[\w+\-]+@ezweb\.ne\.jp\z)/i
     EMAIL_STRICT_PRE = /\A([\w+\-]+\.)*[\w+\-]+\z/
     EMAIL_STRICT     = /\A([\w+\-]+\.)*[\w+\-]+@([a-z\d\-]+\.)+[a-z]+\z/i
     EMAIL_DOMAIN     = /\A([A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9]\.)+[A-Za-z]+\z/

--- a/spec/lib/validators/email_format_validator_spec.rb
+++ b/spec/lib/validators/email_format_validator_spec.rb
@@ -91,6 +91,10 @@ RSpec.describe EmailFormatValidator, type: :model do
       context "host includes '.' just before '@'" do
         it_behaves_like 'invalid email address', 'test.@ezweb.ne.jp'
       end
+
+      context "domain includes ',' instead of '." do
+        it_behaves_like 'invalid email address', 'test@ezweb,ne,jp'
+      end
     end
   end
 
@@ -141,6 +145,10 @@ RSpec.describe EmailFormatValidator, type: :model do
 
     context "domain includes '.' next to '@'" do
       it_behaves_like 'invalid email address', 'test@.example.com'
+    end
+
+    context "domain includes ',' instead of '." do
+      it_behaves_like 'invalid email address', 'test@example,com'
     end
 
     context 'email with length = 201' do


### PR DESCRIPTION
## 問題
`strict: false` で `ezweb.ne.jp` ドメインのとき、
ドメイン部の `.` 部分に任意の文字列を受け付けていた。

 ## 修正
`.` のみを受け付けるように修正