### PR TITLE
`order_format_validator` に2億以上のバリデーションを追加

### DIFF
--- a/lib/validators/order_format_validator.rb
+++ b/lib/validators/order_format_validator.rb
@@ -8,5 +8,8 @@ class OrderFormatValidator < ActiveModel::EachValidator
     if value < 1
       record.errors.add(attribute, (options[:message] || :greater_than), count: 1)
     end
+    if value > 200_000_000
+      record.errors.add(attribute, (options[:message] || :less_than), count: '2億')
+    end
   end
 end

--- a/spec/lib/validators/order_format_validator_spec.rb
+++ b/spec/lib/validators/order_format_validator_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+module Test
+  OrderFormatValidatable = Struct.new(:order) do
+    include ActiveModel::Validations
+
+    validates :order, order_format: true
+  end
+end
+
+RSpec.describe OrderFormatValidator, type: :model do
+  subject { model.valid? }
+
+  let(:model) { Test::OrderFormatValidatable.new(order) }
+
+  context 'When value is less than 1' do
+    let(:order) { 0 }
+
+    it 'order is invalid' do
+      is_expected.to be false
+    end
+  end
+
+  context 'When value is 1' do
+    let(:order) { 1 }
+
+    it 'order is valid' do
+      is_expected.to be true
+    end
+  end
+
+  context 'When value is greater than 200_000_000' do
+    let(:order) { 200_000_001 }
+
+    it 'order is invalid' do
+      is_expected.to be false
+    end
+  end
+
+  context 'When value is 200_000_000' do
+    let(:order) { 200_000_00 }
+
+    it 'order is valid' do
+      is_expected.to be true
+    end
+  end
+
+  context 'When value is not integer' do
+    let(:order) { '1' }
+
+    it 'order is invalid' do
+      is_expected.to be false
+    end
+  end
+end


### PR DESCRIPTION
### 概要
- `positive_number_validator`と同様に、`order_format_validator` に2億以上のバリデーションを追加しました。
- またテストがなかったので追加しました。

https://github.com/palettecloud/palette/issues/13448